### PR TITLE
ci: add a Linux aarch64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
 
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
   # Linux 32-bit
   #- project: 'libretro-infrastructure/ci-templates'
   #  file: '/linux-i686.yml'
@@ -115,6 +119,12 @@ libretro-build-windows-x64:
 libretro-build-linux-x64:
   extends:
     - .libretro-linux-x64-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
   image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-amd64-ubuntu:backports
   variables:


### PR DESCRIPTION
The libretro buildbot ships no aarch64 Linux build of HBMAME, so the core can't be installed from RetroArch's Core Downloader on ARM64 Linux machines (ARM Chromebooks, SBCs, ARM laptops) - even though every other MAME-family core (`mame`, `mame2003_plus`, `mame2010`, `mame2000`, ...) is already there.

The job mirrors `libretro-build-linux-x64`:

```yaml
# Linux ARM 64-bit
libretro-build-linux-aarch64:
  extends:
    - .libretro-linux-aarch64-make-default
    - .core-defs
```

plus the matching `/linux-aarch64.yml` template include.

Why this should just work: `Makefile.libretro` already derives the CPU from the host (`LIBRETRO_CPU = $(UNAME_M)` when neither `ARCH` nor an explicit platform overrides it), so an aarch64 runner selects `aarch64` on its own, and `PTR64 ?= 1` is correct there. The `android-arm64-v8a` job already builds this same tree for ARM64 through GENIE.

**Honest disclaimer on verification:** unlike my other aarch64 CI PRs, I did *not* complete a local aarch64 build of this one - it's a MAME-scale tree and the ARM machine I test on can't finish it in reasonable time. What I did confirm locally is that `make -f Makefile.libretro platform=unix` on an aarch64 host gets past GENIE project generation (`build/generated`, `build/libretro`, `build/projects` all produced) and is compiling C++ without any architecture-related failure. So please treat the CI run on this PR as the real verification - if the job fails, I'm happy to dig in and follow up.
