### PR TITLE
libretro: use latest android NDK r29

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -213,7 +213,7 @@ android-arm64-v8a:
     - .core-defs
   variables:
     TARGET: hbmame
-    ANDROID_NDK_NEXT: 27.3.13750724
+    ANDROID_NDK_NEXT: 29.0.14206865
     WITH_ANDROID: 30
   cache:
     <<: *global_cache


### PR DESCRIPTION
To match CI.