### PR TITLE
ci: build the aarch64 core in the aarch64 image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -137,7 +137,6 @@ libretro-build-linux-aarch64:
   extends:
     - .libretro-linux-aarch64-make-default
     - .core-defs
-  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-amd64-ubuntu:backports
   variables:
     OVERRIDE_CC: /usr/bin/gcc-12
     OVERRIDE_CXX: /usr/bin/g++-12


### PR DESCRIPTION
Fixes libretro/libretro-super#2077: `hbmame_libretro.so` in the Linux aarch64 nightly is an x86-64 binary.

```
$ file hbmame_libretro.so   # from buildbot.libretro.com/nightly/linux/aarch64/latest/
hbmame_libretro.so: ELF 64-bit LSB shared object, x86-64, version 1 (GNU/Linux), ...
```

My aarch64 job in #13 mirrored the x64 job a little too closely and kept its `image:` line, so the job ran the amd64 image on the aarch64 runner and produced an amd64 core. Dropping that one line lets the image from `linux-aarch64.yml` apply. That image installs `gcc-12` and `gcc-14` at `/usr/bin/gcc-12` etc. and defaults `gcc` to 12, so `OVERRIDE_CC`/`OVERRIDE_CXX` still resolve and the job keeps building with the same compiler as x64.

Sorry for the breakage — #13 was the one aarch64 PR I could not build locally (this machine OOMs on hbmame), and this is exactly the kind of thing that slipped through as a result.
